### PR TITLE
Add SurfaceContentReady and SurfaceContentSizeChanged events

### DIFF
--- a/ivi-client/cbindgen.toml
+++ b/ivi-client/cbindgen.toml
@@ -49,6 +49,8 @@ include = [
     "IviGeometryChange",
     "IviZOrderChange",
     "IviOrientationChange",
+    "IviContentReadyInfo",
+    "IviContentSizeChange",
     "IviNotification",
     "NotificationListener",
     "IviNotificationCCallback",

--- a/ivi-client/include/ivi_client.h
+++ b/ivi-client/include/ivi_client.h
@@ -61,6 +61,8 @@ typedef enum IviEventType {
     LAYER_DESTROYED = 10,
     LAYER_VISIBILITY_CHANGED = 11,
     LAYER_OPACITY_CHANGED = 12,
+    SURFACE_CONTENT_READY = 13,
+    SURFACE_CONTENT_SIZE_CHANGED = 14,
 } IviEventType;
 
 /*
@@ -201,6 +203,24 @@ typedef struct IviOrientationChange {
 } IviOrientationChange;
 
 /*
+ Content ready data: buffer dimensions when the first frame is committed.
+ */
+typedef struct IviContentReadyInfo {
+    int32_t width;
+    int32_t height;
+} IviContentReadyInfo;
+
+/*
+ Content size change data: old and new buffer dimensions.
+ */
+typedef struct IviContentSizeChange {
+    int32_t old_width;
+    int32_t old_height;
+    int32_t new_width;
+    int32_t new_height;
+} IviContentSizeChange;
+
+/*
  A notification event delivered to C callbacks.
 
  Only the fields relevant to `event_type` are populated; all others are
@@ -229,6 +249,8 @@ typedef struct IviNotification {
     struct IviGeometryChange dest_geometry;
     struct IviZOrderChange z_order;
     struct IviOrientationChange orientation;
+    struct IviContentReadyInfo content_ready;
+    struct IviContentSizeChange content_size;
 } IviNotification;
 
 /*

--- a/ivi-client/src/ffi.rs
+++ b/ivi-client/src/ffi.rs
@@ -825,6 +825,8 @@ pub enum IviEventType {
     LayerDestroyed = 10,
     LayerVisibilityChanged = 11,
     LayerOpacityChanged = 12,
+    SurfaceContentReady = 13,
+    SurfaceContentSizeChanged = 14,
 }
 
 impl From<&EventType> for IviEventType {
@@ -843,6 +845,8 @@ impl From<&EventType> for IviEventType {
             EventType::LayerDestroyed => IviEventType::LayerDestroyed,
             EventType::LayerVisibilityChanged => IviEventType::LayerVisibilityChanged,
             EventType::LayerOpacityChanged => IviEventType::LayerOpacityChanged,
+            EventType::SurfaceContentReady => IviEventType::SurfaceContentReady,
+            EventType::SurfaceContentSizeChanged => IviEventType::SurfaceContentSizeChanged,
         }
     }
 }
@@ -863,6 +867,8 @@ impl From<IviEventType> for EventType {
             IviEventType::LayerDestroyed => EventType::LayerDestroyed,
             IviEventType::LayerVisibilityChanged => EventType::LayerVisibilityChanged,
             IviEventType::LayerOpacityChanged => EventType::LayerOpacityChanged,
+            IviEventType::SurfaceContentReady => EventType::SurfaceContentReady,
+            IviEventType::SurfaceContentSizeChanged => EventType::SurfaceContentSizeChanged,
         }
     }
 }
@@ -916,6 +922,24 @@ impl Default for IviOrientationChange {
     }
 }
 
+/// Content ready data: buffer dimensions when the first frame is committed.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct IviContentReadyInfo {
+    pub width: i32,
+    pub height: i32,
+}
+
+/// Content size change data: old and new buffer dimensions.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct IviContentSizeChange {
+    pub old_width: i32,
+    pub old_height: i32,
+    pub new_width: i32,
+    pub new_height: i32,
+}
+
 /// A notification event delivered to C callbacks.
 ///
 /// Only the fields relevant to `event_type` are populated; all others are
@@ -941,6 +965,8 @@ pub struct IviNotification {
     pub dest_geometry: IviGeometryChange,
     pub z_order: IviZOrderChange,
     pub orientation: IviOrientationChange,
+    pub content_ready: IviContentReadyInfo,
+    pub content_size: IviContentSizeChange,
 }
 
 fn parse_rect(params: &serde_json::Value, key: &str) -> Rectangle {
@@ -1049,6 +1075,24 @@ fn notification_to_ffi(notif: &Notification) -> IviNotification {
             result.opacity = IviOpacityChange {
                 old_opacity: p["old_opacity"].as_f64().unwrap_or(0.0) as f32,
                 new_opacity: p["new_opacity"].as_f64().unwrap_or(0.0) as f32,
+            };
+        }
+        EventType::SurfaceContentReady => {
+            result.object_type = IviObjectType::Surface;
+            result.object_id = p["surface_id"].as_u64().unwrap_or(0) as u32;
+            result.content_ready = IviContentReadyInfo {
+                width: p["width"].as_i64().unwrap_or(0) as i32,
+                height: p["height"].as_i64().unwrap_or(0) as i32,
+            };
+        }
+        EventType::SurfaceContentSizeChanged => {
+            result.object_type = IviObjectType::Surface;
+            result.object_id = p["surface_id"].as_u64().unwrap_or(0) as u32;
+            result.content_size = IviContentSizeChange {
+                old_width: p["old_width"].as_i64().unwrap_or(0) as i32,
+                old_height: p["old_height"].as_i64().unwrap_or(0) as i32,
+                new_width: p["new_width"].as_i64().unwrap_or(0) as i32,
+                new_height: p["new_height"].as_i64().unwrap_or(0) as i32,
             };
         }
     }

--- a/ivi-client/src/protocol.rs
+++ b/ivi-client/src/protocol.rs
@@ -219,6 +219,8 @@ impl JsonRpcError {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EventType {
     SurfaceCreated,
+    SurfaceContentReady,
+    SurfaceContentSizeChanged,
     SurfaceDestroyed,
     SourceGeometryChanged,
     DestinationGeometryChanged,

--- a/src/controller/notifications.rs
+++ b/src/controller/notifications.rs
@@ -36,6 +36,12 @@ pub enum NotificationType {
     LayerVisibilityChanged,
     /// Layer opacity changed
     LayerOpacityChanged,
+
+    // Surface content events
+    /// Surface received its first buffer commit (content ready)
+    SurfaceContentReady,
+    /// Surface buffer dimensions changed
+    SurfaceContentSizeChanged,
 }
 
 /// Notification data for geometry changes
@@ -113,18 +119,40 @@ pub enum NotificationData {
     SourceGeometryChange(GeometryChangeNotification),
     DestinationGeometryChange(GeometryChangeNotification),
     FocusChange(FocusChangeNotification),
-    SurfaceCreated { surface_id: u32 },
-    SurfaceDestroyed { surface_id: u32 },
+    SurfaceCreated {
+        surface_id: u32,
+    },
+    SurfaceDestroyed {
+        surface_id: u32,
+    },
     VisibilityChange(VisibilityChangeNotification),
     OpacityChange(OpacityChangeNotification),
     OrientationChange(OrientationChangeNotification),
     ZOrderChange(ZOrderChangeNotification),
 
     // Layer notifications
-    LayerCreated { layer_id: u32 },
-    LayerDestroyed { layer_id: u32 },
+    LayerCreated {
+        layer_id: u32,
+    },
+    LayerDestroyed {
+        layer_id: u32,
+    },
     LayerVisibilityChange(LayerVisibilityChangeNotification),
     LayerOpacityChange(LayerOpacityChangeNotification),
+
+    // Surface content notifications
+    SurfaceContentReady {
+        surface_id: u32,
+        width: i32,
+        height: i32,
+    },
+    SurfaceContentSizeChanged {
+        surface_id: u32,
+        old_width: i32,
+        old_height: i32,
+        new_width: i32,
+        new_height: i32,
+    },
 }
 
 /// A notification event
@@ -388,6 +416,55 @@ impl NotificationManager {
             new_visibility
         );
 
+        self.emit(notification);
+    }
+
+    /// Emit a surface content ready notification
+    pub fn emit_surface_content_ready(&self, surface_id: u32, width: i32, height: i32) {
+        let notification = Notification {
+            notification_type: NotificationType::SurfaceContentReady,
+            data: NotificationData::SurfaceContentReady {
+                surface_id,
+                width,
+                height,
+            },
+        };
+        jinfo!(
+            "Surface content ready: surface {} ({}x{})",
+            surface_id,
+            width,
+            height
+        );
+        self.emit(notification);
+    }
+
+    /// Emit a surface content size changed notification
+    pub fn emit_surface_content_size_changed(
+        &self,
+        surface_id: u32,
+        old_width: i32,
+        old_height: i32,
+        new_width: i32,
+        new_height: i32,
+    ) {
+        let notification = Notification {
+            notification_type: NotificationType::SurfaceContentSizeChanged,
+            data: NotificationData::SurfaceContentSizeChanged {
+                surface_id,
+                old_width,
+                old_height,
+                new_width,
+                new_height,
+            },
+        };
+        jinfo!(
+            "Surface content size changed: surface {} ({}x{} -> {}x{})",
+            surface_id,
+            old_width,
+            old_height,
+            new_width,
+            new_height
+        );
         self.emit(notification);
     }
 

--- a/src/controller/state.rs
+++ b/src/controller/state.rs
@@ -403,6 +403,17 @@ impl StateManager {
 
             // Check property changes and emit notifications
             if let Some(old) = old_state {
+                // Detect orig_size transitions for content ready / size changed events
+                let (ow, oh) = old.orig_size;
+                let (nw, nh) = new_state.orig_size;
+                if let Ok(nm) = self.notification_manager.lock() {
+                    if (ow, oh) == (0, 0) && (nw, nh) != (0, 0) {
+                        nm.emit_surface_content_ready(surface_id, nw, nh);
+                    } else if (ow, oh) != (0, 0) && (nw, nh) != (0, 0) && (ow, oh) != (nw, nh) {
+                        nm.emit_surface_content_size_changed(surface_id, ow, oh, nw, nh);
+                    }
+                }
+
                 // Try to filter using event_mask (0 means unknown/no filter)
                 let event_mask = surface.event_mask();
                 if event_mask == 0 {

--- a/src/rpc/notification_bridge.rs
+++ b/src/rpc/notification_bridge.rs
@@ -36,6 +36,38 @@ impl NotificationBridge {
                 }),
             ),
 
+            NotificationData::SurfaceContentReady {
+                surface_id,
+                width,
+                height,
+            } => (
+                EventType::SurfaceContentReady,
+                json!({
+                    "event_type": "SurfaceContentReady",
+                    "surface_id": surface_id,
+                    "width": width,
+                    "height": height,
+                }),
+            ),
+
+            NotificationData::SurfaceContentSizeChanged {
+                surface_id,
+                old_width,
+                old_height,
+                new_width,
+                new_height,
+            } => (
+                EventType::SurfaceContentSizeChanged,
+                json!({
+                    "event_type": "SurfaceContentSizeChanged",
+                    "surface_id": surface_id,
+                    "old_width": old_width,
+                    "old_height": old_height,
+                    "new_width": new_width,
+                    "new_height": new_height,
+                }),
+            ),
+
             NotificationData::SurfaceDestroyed { surface_id } => (
                 EventType::SurfaceDestroyed,
                 json!({

--- a/src/rpc/protocol.rs
+++ b/src/rpc/protocol.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 pub enum EventType {
     // Surface events
     SurfaceCreated,
+    SurfaceContentReady,
+    SurfaceContentSizeChanged,
     SurfaceDestroyed,
     SourceGeometryChanged,
     DestinationGeometryChanged,


### PR DESCRIPTION
## Summary

- Add `SurfaceContentReady` event: fired when an IVI surface commits its first buffer (orig_size transitions from `(0,0)` to non-zero)
- Add `SurfaceContentSizeChanged` event: fired when a surface's committed buffer dimensions change (resize by the Wayland client)
- Both events are mutually exclusive — `SurfaceContentReady` fires only on the first commit; subsequent size changes fire `SurfaceContentSizeChanged`

## Changes

- **`src/controller/notifications.rs`**: new `NotificationType`/`NotificationData` variants and `emit_surface_content_ready` / `emit_surface_content_size_changed` helpers
- **`src/controller/state.rs`**: detect `orig_size` transitions in `handle_surface_configured()`
- **`src/rpc/protocol.rs`**: new `SurfaceContentReady` / `SurfaceContentSizeChanged` RPC `EventType` variants
- **`src/rpc/notification_bridge.rs`**: bridge match arms with JSON payloads (`surface_id`, `width`, `height` / `old_width`, `old_height`, `new_width`, `new_height`)
- **`ivi-client/src/protocol.rs`**: new client-side `EventType` variants
- **`ivi-client/src/ffi.rs`**: `IviContentReadyInfo` / `IviContentSizeChange` C structs, `IviEventType` variants 13/14, fields added to `IviNotification`, `notification_to_ffi()` updated
- **`ivi-client/cbindgen.toml`**: export new structs
- **`ivi-client/include/ivi_client.h`**: regenerated

## Test plan

- [x] `cargo build` passes (server + client)
- [x] `cargo test` passes (253 tests)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)